### PR TITLE
Allow Operations Managers to access Advanced Analytics

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -97,7 +97,7 @@ function App() {
               </ProtectedRoute>
             } />
 
-            {/* ACCESS_ANALYTICS_FULL: Admin only */}
+            {/* ACCESS_ANALYTICS_FULL: Admin and Ops only */}
             <Route path="/events/:eventId/dashboard/advanced" element={
               <ProtectedRoute requiredCapability="ACCESS_ANALYTICS_FULL">
                 <AdvancedDashboard />
@@ -184,7 +184,7 @@ function App() {
             {/* Remove duplicate routes - these are handled by the event-specific routes above */}
 
             {/* 🧪 TEST ROUTES for Analytics Components */}
-            {/* ACCESS_ANALYTICS_FULL: Admin only */}
+            {/* ACCESS_ANALYTICS_FULL: Admin and Ops only */}
             <Route path="/test-analytics/:eventId" element={
               <ProtectedRoute requiredCapability="ACCESS_ANALYTICS_FULL">
                 <SpecificAnalyticsExamples />

--- a/frontend/src/constants/permissions.js
+++ b/frontend/src/constants/permissions.js
@@ -30,7 +30,7 @@ export const PERMISSIONS = {
     VIEW_INVENTORY: ['admin', 'operations_manager', 'staff'],
     CHECK_IN_GUESTS: ['admin', 'operations_manager', 'staff'],
   
-    ACCESS_ANALYTICS_FULL: ['admin'], // Complete analytics suite
+    ACCESS_ANALYTICS_FULL: ['admin', 'operations_manager'], // Complete analytics suite - Admin and Ops
     ACCESS_ANALYTICS_BASIC: ['admin', 'operations_manager'], // Staff excluded
   
     ASSIGN_ROLES: ['admin'], // Ops cannot change roles

--- a/frontend/src/docs/permissions-matrix.md
+++ b/frontend/src/docs/permissions-matrix.md
@@ -33,7 +33,7 @@ MANAGE_EVENTS	✔	✔	✖	Staff cannot modify event settings
 VIEW_EVENTS	✔	✔	✔	All roles can view events assigned to them
 MANAGE_INVENTORY	✔	✔	✖	Inventory is an Ops+Admin responsibility
 CHECK_IN_GUESTS	✔	✔	✔	All operational roles can check attendees in
-ACCESS_ANALYTICS_FULL	✔	✖	✖	Complete suite: exports, insights, etc.
+ACCESS_ANALYTICS_FULL	✔	✔	✖	Complete suite: exports, insights, etc. (Admin and Ops)
 ACCESS_ANALYTICS_BASIC	✔	✔	✖	Ops has dashboard viewing only
 ASSIGN_ROLES	✔	✖	✖	Role changes restricted to Admin
 🧩 Backend Controller Mapping


### PR DESCRIPTION
- Updated ACCESS_ANALYTICS_FULL permission to include operations_manager role
- Updated route comments to reflect Admin and Ops access
- Updated permissions matrix documentation
- Fixed Typography typo in ComprehensiveAnalytics component

Ops users can now access Advanced Analytics dashboard, while Staff remains restricted.